### PR TITLE
boards: arm: Adjust xiao_ble for default bootloader.

### DIFF
--- a/boards/arm/xiao_ble/doc/index.rst
+++ b/boards/arm/xiao_ble/doc/index.rst
@@ -82,18 +82,36 @@ LED
 Programming and Debugging
 *************************
 
-The XIAO BLE ships with a bootloader. However, this guide doesn't describe how
-to use it and instead an External Debug Probe is used in order to program the
-board. If you have one, you can also use an external :ref:`debug probe
-<debug-probes>` to flash and debug Zephyr applications, but you need to solder
-an SWD header onto the back side of the board.
+The XIAO BLE ships with the `Adafruit nRF52 Bootloader`_ which supports flashing
+using `UF2`_. Doing so allows easy flashing of new images, but does not support
+debugging the device.
+
+UF2 Flashing
+============
+
+To enter the bootloader, connect the USB port of the XIAO BLE to your host, and
+double tap the reset botton to the left of the USB connector. A mass storage
+device named `XIAO BLE` should appear on the host. Using the command line, or
+your file manager copy the `zephyr/zephyr.uf2` file from your build to the base
+of the `XIAO BLE` mass storage device. The XIAO BLE will automatically reset
+and launch the newly flashed application.
+
+
+External Debugger
+=================
+
+In order to support debugging the device, instead of using the bootloader, you
+can use an External Debug Probe to program the board. If you have one, you can
+also use an external :ref:`debug probe <debug-probes>` to flash and debug
+Zephyr applications, but you need to solder an SWD header onto the back side of
+the board.
 
 For Segger J-Link debug probes, follow the instructions in the
 :ref:`jlink-external-debug-probe` page to install and configure all the
 necessary software.
 
 Flashing
-========
+--------
 
 Follow the instructions in the :ref:`jlink-external-debug-probe` page to install
 and configure all the necessary software. Then build and flash applications as
@@ -122,7 +140,7 @@ initialized before any text is printed, as below:
    :gen-args: -DCONFIG_BOOT_DELAY=5000
 
 Debugging
-=========
+---------
 
 Refer to the :ref:`jlink-external-debug-probe` page to learn about debugging
 boards with a Segger IC.
@@ -158,6 +176,8 @@ References
 
 .. target-notes::
 
+.. _Adafruit nRF52 Bootloader: https://github.com/adafruit/Adafruit_nRF52_Bootloader
+.. _UF2: https://github.com/microsoft/uf2
 .. _XIAO BLE wiki: https://wiki.seeedstudio.com/XIAO_BLE/
 .. _pinouts: https://wiki.seeedstudio.com/XIAO_BLE/#hardware-overview
 .. _schematic: https://wiki.seeedstudio.com/XIAO_BLE/#resources

--- a/boards/arm/xiao_ble/xiao_ble.dts
+++ b/boards/arm/xiao_ble/xiao_ble.dts
@@ -21,7 +21,7 @@
 		zephyr,bt-c2h-uart = &usb_cdc_acm_uart;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,code-partition = &slot0_partition;
+		zephyr,code-partition = &code_partition;
 	};
 
 	leds {
@@ -139,30 +139,34 @@
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
-
-		/* The size of this partition ensures that MCUBoot can be built
-		 * with an RTT console, CDC ACM support, and w/o optimizations.
+		
+		sd_partition: partition@0 {
+			label = "softdevice";
+			reg = <0x00000000 0x00027000>;
+		};
+		
+		code_partition: partition@27000 {
+			label = "code_partition";
+			reg = <0x00027000 0x000c5000>;
+		};
+		        
+		/*
+		 * The flash starting at 0x000ec000 and ending at
+		 * 0x000f3fff is reserved for use by the application.
 		 */
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x00012000>;
-		};
-
-		slot0_partition: partition@12000 {
-			label = "image-0";
-			reg = <0x00012000 0x00069000>;
-		};
-		slot1_partition: partition@7b000 {
-			label = "image-1";
-			reg = <0x0007b000 0x00069000>;
-		};
-		scratch_partition: partition@e4000 {
-			label = "image-scratch";
-			reg = <0x000e4000 0x00018000>;
-		};
-		storage_partition: partition@fc000 {
+		        
+		/*
+		 * Storage partition will be used by FCB/LittleFS/NVS
+		 * if enabled.
+		 */
+		storage_partition: partition@ec000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000ec000 0x00008000>;
+		};
+		
+		boot_partition: partition@f4000 {
+			label = "adafruit_boot";
+			reg = <0x000f4000 0x0000c000>;
 		};
 	};
 };

--- a/boards/arm/xiao_ble/xiao_ble_defconfig
+++ b/boards/arm/xiao_ble/xiao_ble_defconfig
@@ -22,6 +22,9 @@ CONFIG_CONSOLE=y
 # enable USB
 CONFIG_USB_DEVICE_STACK=y
 
+# Build UF2 by default, supported by the Adafruit nRF52 Bootloader
+CONFIG_BUILD_OUTPUT_UF2=y
+
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
 


### PR DESCRIPTION
Adjust the flash partitions for default Adafruit nRF52
Bootloader, enable UF2 build by default, and document
how to flash UF2 images to the device.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>